### PR TITLE
Add .gitattributes so the working tree can be clean

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,28 @@
+# Line endings, so a Windows clone and a Linux CI runner see the same bytes.
+#
+# Added 2026-07-29. Without it, `core.autocrlf` (on by default in the Windows Git
+# installer) rewrote every text file to CRLF on checkout, and `git status` in
+# this repo reported 559 modified files whose only difference was line endings —
+# `git diff --ignore-cr-at-eol` was empty. A working tree that is never clean is
+# a working tree nobody reads, and this repo carries two mirrors of OBC artifacts
+# (src/accelerapp/hardware/registry.json, src/accelerapp/firmware/templates.json)
+# whose whole value is being byte-identical to the core agent's copies.
+
+* text=auto eol=lf
+
+# Windows batch files must stay CRLF to run at all.
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# Never normalise or diff these as text.
+*.png  binary
+*.jpg  binary
+*.jpeg binary
+*.gif  binary
+*.ico  binary
+*.webp binary
+*.pdf  binary
+*.zip  binary
+*.gz   binary
+*.whl  binary
+*.bin  binary


### PR DESCRIPTION
Without a .gitattributes, core.autocrlf rewrote every text file on checkout and `git status` reported 559 modified files whose `git diff --ignore-cr-at-eol` was empty. Nothing had changed; the working tree simply could never be clean, which means it stops being read.

This repo also carries two mirrors of OBC artifacts — src/accelerapp/hardware/registry.json and
src/accelerapp/firmware/templates.json — whose whole value is being byte-identical to the core agent's copies. Both currently match, but by luck rather than by a gate: neither is listed in OBC-Prime's vendored ARTIFACTS.


Claude-Session: https://claude.ai/code/session_01M14aUKCDwvs7114QPpGeWV